### PR TITLE
Adding new cuts for the imaging - Scatter test and angle / Expanding …

### DIFF
--- a/Imaging/EventCategorizerImaging.cpp
+++ b/Imaging/EventCategorizerImaging.cpp
@@ -32,123 +32,207 @@ bool EventCategorizerImaging::init()
 
   fOutputEvents = new JPetTimeWindow("JPetEvent");
 
-  if (isOptionSet(fParams.getOptions(), kMinAnnihilationParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kMinAnnihilationParamKey)) {
     fMinAnnihilationTOT = getOptionAsFloat(fParams.getOptions(), kMinAnnihilationParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMinAnnihilationParamKey.c_str(),
                  fMinAnnihilationTOT));
   }
-  if (isOptionSet(fParams.getOptions(), kMaxAnnihilationParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kMaxAnnihilationParamKey)) {
     fMaxAnnihilationTOT = getOptionAsFloat(fParams.getOptions(), kMaxAnnihilationParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxAnnihilationParamKey.c_str(),
                  fMaxAnnihilationTOT));
   }
-  if (isOptionSet(fParams.getOptions(), kMaxZPosParamKey))
-  {
-    fMaxZPos = getOptionAsFloat(fParams.getOptions(), kMaxZPosParamKey);
+  if (isOptionSet(fParams.getOptions(), kMinPromptTOTParamKey)) {
+    fMinPromptTOT = getOptionAsFloat(fParams.getOptions(), kMinPromptTOTParamKey);
+  } else {
+    WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMinPromptTOTParamKey.c_str(),
+                 fMinPromptTOT));
   }
-  else
-  {
+  if (isOptionSet(fParams.getOptions(), kMaxPromptTOTParamKey)) {
+    fMaxPromptTOT = getOptionAsFloat(fParams.getOptions(), kMaxPromptTOTParamKey);
+  } else {
+    WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxPromptTOTParamKey.c_str(),
+                 fMaxPromptTOT));
+  }
+  if (isOptionSet(fParams.getOptions(), kMaxZPosParamKey)) {
+    fMaxZPos = getOptionAsFloat(fParams.getOptions(), kMaxZPosParamKey);
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxZPosParamKey.c_str(), fMaxZPos));
   }
-  if (isOptionSet(fParams.getOptions(), kMaxDistOfDecayPlaneFromCenterParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kMaxDistOfDecayPlaneFromCenterParamKey)) {
     fMaxDistOfDecayPlaneFromCenter = getOptionAsFloat(fParams.getOptions(), kMaxDistOfDecayPlaneFromCenterParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxDistOfDecayPlaneFromCenterParamKey.c_str(),
                  fMaxDistOfDecayPlaneFromCenter));
   }
-  if (isOptionSet(fParams.getOptions(), kMaxTimeDiffParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kMaxTimeDiffParamKey)) {
     fMaxTimeDiff = getOptionAsFloat(fParams.getOptions(), kMaxTimeDiffParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxTimeDiffParamKey.c_str(), fMaxTimeDiff));
   }
-  if (isOptionSet(fParams.getOptions(), kBackToBackAngleWindowParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kBackToBackAngleWindowParamKey)) {
     fBackToBackAngleWindow = getOptionAsFloat(fParams.getOptions(), kBackToBackAngleWindowParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kBackToBackAngleWindowParamKey.c_str(),
                  fBackToBackAngleWindow));
   }
-  if (isOptionSet(fParams.getOptions(), kDecayInto3MinAngleParamKey))
-  {
+  if (isOptionSet(fParams.getOptions(), kDecayInto3MinAngleParamKey)) {
     fDecayInto3MinAngle = getOptionAsFloat(fParams.getOptions(), kDecayInto3MinAngleParamKey);
-  }
-  else
-  {
+  } else {
     WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kDecayInto3MinAngleParamKey.c_str(),
                  fDecayInto3MinAngle));
   }
+  if (isOptionSet(fParams.getOptions(), kMaxScattTestValueParamKey)) {
+    fScattTestValue = getOptionAsFloat(fParams.getOptions(), kMaxScattTestValueParamKey);
+  } else {
+    WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMaxScattTestValueParamKey.c_str(),
+                 fScattTestValue));
+  }
+  if (isOptionSet(fParams.getOptions(), kMinAngleWindowValueParamKey)) {
+    fMinAngleWindow = getOptionAsFloat(fParams.getOptions(), kMinAngleWindowValueParamKey);
+  } else {
+    WARNING(Form("No value of the %s parameter provided by the user. Using default value of %lf.", kMinAngleWindowValueParamKey.c_str(),
+                 fMinAngleWindow));
+  }
   if (fSaveControlHistos)
   {
-    getStatistics().createHistogram(new TH1F("2Gamma_TimeDiff", "2 Gamma Hits Time Difference", 200, 0.0, 10.0));
+    //Dynamic binning is not neccessary, as it is enough to plot histogram before and after cut in the same ranges to compare.
+      
+    getStatistics().createHistogram(new TH1F("2Gamma_TimeDiff", "2 Gamma Hits Time Difference", 200, -0.025, 9.975));
     getStatistics().getHisto1D("2Gamma_TimeDiff")->SetXTitle("Hits time difference [ns]");
     getStatistics().getHisto1D("2Gamma_TimeDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("2Gamma_ThetaDiff", "2 Gamma Hits angles", 180, -0.5, 179.5));
+    //1 deg bin can generate artifacts on the angle -> changing to 0.1 deg bin
+    getStatistics().createHistogram(new TH1F("2Gamma_ThetaDiff", "2 Gamma Hits angles", 2000, -0.05, 199.95));
     getStatistics().getHisto1D("2Gamma_ThetaDiff")->SetXTitle("Hits theta diff [deg]");
     getStatistics().getHisto1D("2Gamma_ThetaDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("2Gamma_DLOR", "Delta LOR distance", 100, 0.0, 50.0));
+    getStatistics().createHistogram(new TH1F("2Gamma_DLOR", "Delta LOR distance", 100, -0.25, 49.75));
     getStatistics().getHisto1D("2Gamma_DLOR")->SetXTitle("Delta LOR [cm]");
     getStatistics().getHisto1D("2Gamma_DLOR")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Gamma_ScattTest", "Scatter test for annihilation hits", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("2Gamma_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("2Gamma_ScattTest")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("2Annih_TimeDiff", "2 gamma annihilation Hits Time Difference", 200, 0.0, fMaxTimeDiff / 1000.0));
-    getStatistics().getHisto1D("2Annih_TimeDiff")->SetXTitle("Time difference between 2 annihilation hits [ns]");
-    getStatistics().getHisto1D("2Annih_TimeDiff")->SetYTitle("Counts");
+    getStatistics().createHistogram(new TH1F("2Anni_TimeDiff", "2 gamma annihilation Hits Time Difference", 200, -0.025, 9.975));
+    getStatistics().getHisto1D("2Anni_TimeDiff")->SetXTitle("Time difference between 2 annihilation hits [ns]");
+    getStatistics().getHisto1D("2Anni_TimeDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("2Annih_ThetaDiff", "Annihilation Hits Theta Diff", (int)4 * fBackToBackAngleWindow,
-                                             180. - fBackToBackAngleWindow, 180. + fBackToBackAngleWindow));
-    getStatistics().getHisto1D("2Annih_ThetaDiff")->SetXTitle("Annihilation hits theta diff [deg]");
-    getStatistics().getHisto1D("2Annih_ThetaDiff")->SetYTitle("Counts");
+    //1 deg bin can generate artifacts on the angle -> changing to 0.1 deg bin
+    getStatistics().createHistogram(new TH1F("2Anni_ThetaDiff", "Annihilation Hits Theta Diff", 2000, -0.05, 199.95));
+    getStatistics().getHisto1D("2Anni_ThetaDiff")->SetXTitle("Annihilation hits theta diff [deg]");
+    getStatistics().getHisto1D("2Anni_ThetaDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("2Annih_DLOR", "Delta LOR distance", 100, 0.0, 50.0));
-    getStatistics().getHisto1D("2Annih_ThetaDiff")->SetXTitle("Annihilation hits Delta LOR [cm]");
-    getStatistics().getHisto1D("2Annih_ThetaDiff")->SetYTitle("Counts");
+    getStatistics().createHistogram(new TH1F("2Anni_DLOR", "Delta LOR distance", 100, -0.25, 49.75));
+    getStatistics().getHisto1D("2Anni_DLOR")->SetXTitle("Annihilation hits Delta LOR [cm]");
+    getStatistics().getHisto1D("2Anni_DLOR")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Anni_ScattTest", "Scatter test for annihilation hits classified as 2G", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("2Anni_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("2Anni_ScattTest")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH2F("2Annih_XY", "Reconstructed XY position of annihilation point", 220, -54.5, 54.5, 220, -54.5, 54.5));
-    getStatistics().getHisto2D("2Annih_XY")->SetXTitle("Annihilation point X [cm]");
-    getStatistics().getHisto2D("2Annih_XY")->SetYTitle("Annihilation point Y [cm]");
+    getStatistics().createHistogram(new TH2F("2Anni_XY", "Reconstructed XY position of annihilation point", 220, -55.25, 54.75, 220, -55.25, 54.75));
+    getStatistics().getHisto2D("2Anni_XY")->SetXTitle("Annihilation point X [cm]");
+    getStatistics().getHisto2D("2Anni_XY")->SetYTitle("Annihilation point Y [cm]");
 
-    getStatistics().createHistogram(new TH1F("2Annih_Z", "Reconstructed Z position of annihilation point", 220, -54.5, 54.5));
-    getStatistics().getHisto1D("2Annih_Z")->SetXTitle("Annihilation point Z [cm]");
-    getStatistics().getHisto1D("2Annih_Z")->SetYTitle("Counts");
+    getStatistics().createHistogram(new TH1F("2Anni_Z", "Reconstructed Z position of annihilation point", 220, -55.25, 54.75));
+    getStatistics().getHisto1D("2Anni_Z")->SetXTitle("Annihilation point Z [cm]");
+    getStatistics().getHisto1D("2Anni_Z")->SetYTitle("Counts");
+    
+//---------------------------------------------------------------------------------------------------------------------
+    
+    getStatistics().createHistogram(new TH1F("2Gamma1Prompt_TimeDiff", "2 Gamma Hits Time Difference", 200, -0.025, 9.975));
+    getStatistics().getHisto1D("2Gamma1Prompt_TimeDiff")->SetXTitle("Hits time difference [ns]");
+    getStatistics().getHisto1D("2Gamma1Prompt_TimeDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH2F("3GammaThetas", "3 Gamma Thetas plot", 251, -0.5, 250.5, 201, -0.5, 200.5));
-    getStatistics().getHisto2D("3GammaThetas")->SetXTitle("Transformed thetas 1-2 [deg]");
-    getStatistics().getHisto2D("3GammaThetas")->SetYTitle("Transformed thetas 2-3 [deg]");
+    //1 deg bin can generate artifacts on the angle -> changing to 0.1 deg bin
+    getStatistics().createHistogram(new TH1F("2Gamma1Prompt_ThetaDiff", "2 Gamma Hits angles", 2000, -0.05, 199.95));
+    getStatistics().getHisto1D("2Gamma1Prompt_ThetaDiff")->SetXTitle("Hits theta diff [deg]");
+    getStatistics().getHisto1D("2Gamma1Prompt_ThetaDiff")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Gamma1Prompt_AnniPromptThetaDiff", "2 Gamma Hits angles", 2000, -0.05, 199.95));
+    getStatistics().getHisto1D("2Gamma1Prompt_AnniPromptThetaDiff")->SetXTitle("Hits theta diff [deg]");
+    getStatistics().getHisto1D("2Gamma1Prompt_AnniPromptThetaDiff")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("3GammaPlaneDist", "3 Gamma Plane Distance to Center", 100, 0.0, 10.0));
-    getStatistics().getHisto1D("3GammaPlaneDist")->SetXTitle("Distance [cm]");
-    getStatistics().getHisto1D("3GammaPlaneDist")->SetYTitle("Counts");
+    getStatistics().createHistogram(new TH1F("2Gamma1Prompt_DLOR", "Delta LOR distance", 100, -0.25, 49.75));
+    getStatistics().getHisto1D("2Gamma1Prompt_DLOR")->SetXTitle("Delta LOR [cm]");
+    getStatistics().getHisto1D("2Gamma1Prompt_DLOR")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Gamma1Prompt_ScattTest", "Scatter test for annihilation hits", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("2Gamma1Prompt_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("2Gamma1Prompt_ScattTest")->SetYTitle("Counts");
 
-    getStatistics().createHistogram(new TH1F("3GammaTimeDiff", "3 gamma last and first hit time difference", 200, 0.0, 20.0));
-    getStatistics().getHisto1D("3GammaTimeDiff")->SetXTitle("Time difference [ns]");
-    getStatistics().getHisto1D("3GammaTimeDiff")->SetYTitle("Counts");
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_TimeDiff", "2 gamma annihilation Hits Time Difference", 200, -0.025, 9.975));
+    getStatistics().getHisto1D("2Anni1Prompt_TimeDiff")->SetXTitle("Time difference between 2 annihilation hits [ns]");
+    getStatistics().getHisto1D("2Anni1Prompt_TimeDiff")->SetYTitle("Counts");
+
+    //1 deg bin can generate artifacts on the angle -> changing to 0.1 deg bin
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_ThetaDiff", "Annihilation Hits Theta Diff", 2000, -0.05, 199.95));
+    getStatistics().getHisto1D("2Anni1Prompt_ThetaDiff")->SetXTitle("Annihilation hits theta diff [deg]");
+    getStatistics().getHisto1D("2Anni1Prompt_ThetaDiff")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_AnniPromptThetaDiff", "Annihilation Hits Theta Diff", 2000, -0.05, 199.95));
+    getStatistics().getHisto1D("2Anni1Prompt_AnniPromptThetaDiff")->SetXTitle("Annihilation hits theta diff [deg]");
+    getStatistics().getHisto1D("2Anni1Prompt_AnniPromptThetaDiff")->SetYTitle("Counts");
+
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_DLOR", "Delta LOR distance", 100, -0.25, 49.75));
+    getStatistics().getHisto1D("2Anni1Prompt_DLOR")->SetXTitle("Annihilation hits Delta LOR [cm]");
+    getStatistics().getHisto1D("2Anni1Prompt_DLOR")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Anni_ScattTest", "Scatter test for annihilation hits classified as 2G", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("2Anni1Prompt_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("2Anni1Prompt_ScattTest")->SetYTitle("Counts");
+
+    getStatistics().createHistogram(new TH2F("2Anni1Prompt_XY", "Reconstructed XY position of annihilation point", 220, -55.25, 54.75, 220, -55.25, 54.75));
+    getStatistics().getHisto2D("2Anni1Prompt_XY")->SetXTitle("Annihilation point X [cm]");
+    getStatistics().getHisto2D("2Anni1Prompt_XY")->SetYTitle("Annihilation point Y [cm]");
+
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_Z", "Reconstructed Z position of annihilation point", 220, -55.25, 54.75));
+    getStatistics().getHisto1D("2Anni1Prompt_Z")->SetXTitle("Annihilation point Z [cm]");
+    getStatistics().getHisto1D("2Anni1Prompt_Z")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("2Anni1Prompt_Lifetime", "Positron lifetime distribution", 4000, -200.05, 199.95));
+    getStatistics().getHisto1D("2Anni1Prompt_Lifetime")->SetXTitle("Positron lifetime [ns]");
+    getStatistics().getHisto1D("2Anni1Prompt_Lifetime")->SetYTitle("Counts");
+    
+//---------------------------------------------------------------------------------------------------------------------
+    
+    getStatistics().createHistogram(new TH2F("3Gamma_Thetas", "3 Gamma Thetas plot", 2500, -0.05, 249.95, 2000, -0.05, 199.95));
+    getStatistics().getHisto2D("3Gamma_Thetas")->SetXTitle("Transformed thetas 1-2 [deg]");
+    getStatistics().getHisto2D("3Gamma_Thetas")->SetYTitle("Transformed thetas 2-3 [deg]");
+
+    getStatistics().createHistogram(new TH1F("3Gamma_PlaneDist", "3 Gamma Plane Distance to Center", 100, -0.25, 49.75));
+    getStatistics().getHisto1D("3Gamma_PlaneDist")->SetXTitle("Distance [cm]");
+    getStatistics().getHisto1D("3Gamma_PlaneDist")->SetYTitle("Counts");
+
+    getStatistics().createHistogram(new TH1F("3Gamma_TimeDiff", "3 gamma last and first hit time difference", 200, -0.025, 9.975));
+    getStatistics().getHisto1D("3Gamma_TimeDiff")->SetXTitle("Time difference [ns]");
+    getStatistics().getHisto1D("3Gamma_TimeDiff")->SetYTitle("Counts");
+
+    getStatistics().createHistogram(new TH1F("3Gamma_ScattTest", "Scatter test for every pair of the annihilation hits", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("3Gamma_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("3Gamma_ScattTest")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH2F("3Anni_Thetas", "3 Gamma Thetas plot after cut", 2500, -0.05, 249.95, 2000, -0.05, 199.95));
+    getStatistics().getHisto2D("3Anni_Thetas")->SetXTitle("Transformed thetas 1-2 [deg]");
+    getStatistics().getHisto2D("3Anni_Thetas")->SetYTitle("Transformed thetas 2-3 [deg]");
+    
+    getStatistics().createHistogram(
+        new TH1F("3Anni_PlaneDist", "3 Gamma Annihilation Plane Distance to Center", 1100, -0.25, 49.75));
+    getStatistics().getHisto1D("3Anni_PlaneDist")->SetXTitle("Distance [cm]");
+    getStatistics().getHisto1D("3Anni_PlaneDist")->SetYTitle("Counts");
 
     getStatistics().createHistogram(
-        new TH1F("3AnnihPlaneDist", "3 Gamma Annihilation Plane Distance to Center", 100, 0.0, fMaxDistOfDecayPlaneFromCenter));
-    getStatistics().getHisto1D("3AnnihPlaneDist")->SetXTitle("Distance [cm]");
-    getStatistics().getHisto1D("3AnnihPlaneDist")->SetYTitle("Counts");
-
-    getStatistics().createHistogram(
-        new TH1F("3AnnihTimeDiff", "3 gamma Annihilation last and first hit time difference", 200, 0.0, fMaxTimeDiff / 1000.0));
-    getStatistics().getHisto1D("3AnnihTimeDiff")->SetXTitle("Time difference [ns]");
-    getStatistics().getHisto1D("3AnnihTimeDiff")->SetYTitle("Counts");
+        new TH1F("3Anni_TimeDiff", "3 gamma Annihilation last and first hit time difference", 200, -0.025, 9.975));
+    getStatistics().getHisto1D("3Anni_TimeDiff")->SetXTitle("Time difference [ns]");
+    getStatistics().getHisto1D("3Anni_TimeDiff")->SetYTitle("Counts");
+    
+    getStatistics().createHistogram(new TH1F("3Anni_ScattTest", "Scatter test for every pair of the annihilation hits", 500, -5.05, 44.95));
+    getStatistics().getHisto1D("3Anni_ScattTest")->SetXTitle("Scatter test [ns]");
+    getStatistics().getHisto1D("3Anni_ScattTest")->SetYTitle("Counts");
   }
   return true;
 }
@@ -202,6 +286,7 @@ void EventCategorizerImaging::saveEvents(const vector<JPetEvent>& events)
 JPetEvent EventCategorizerImaging::imageReconstruction(vector<JPetHit> hits)
 {
   JPetEvent imagingEvent;
+  uint promptIndex = -1;
   for (unsigned i = 0; i < hits.size(); i++)
   {
     double TOTofHit = EventCategorizerTools::calculateTOT(hits[i]);
@@ -209,8 +294,16 @@ JPetEvent EventCategorizerImaging::imageReconstruction(vector<JPetHit> hits)
     {
       imagingEvent.addHit(hits[i]);
     }
+    if (TOTofHit >= fMinPromptTOT && TOTofHit <= fMaxPromptTOT && fabs(hits[i].getPosZ()) < fMaxZPos)
+    {
+      imagingEvent.addHit(hits[i]);
+      if (promptIndex == -1)
+        promptIndex = i;
+      else
+        promptIndex = -2;
+    }
   }
-  if (EventCategorizerTools::stream2Gamma(imagingEvent, getStatistics(), fSaveControlHistos, fBackToBackAngleWindow, fMaxTimeDiff))
+  if (EventCategorizerTools::stream2Gamma(imagingEvent, getStatistics(), fSaveControlHistos, fBackToBackAngleWindow, fMaxTimeDiff, fScattTestValue))
   {
     imagingEvent.addEventType(JPetEventType::k2Gamma);
   }
@@ -218,6 +311,14 @@ JPetEvent EventCategorizerImaging::imageReconstruction(vector<JPetHit> hits)
                                           fMaxDistOfDecayPlaneFromCenter))
   {
     imagingEvent.addEventType(JPetEventType::k3Gamma);
+  }
+  if (promptIndex >= 0) {
+    if (EventCategorizerTools::stream2GammaPlus1Prompt(imagingEvent, getStatistics(), fSaveControlHistos, fBackToBackAngleWindow, fMinAngleWindow, 
+        fMaxTimeDiff, fScattTestValue, promptIndex))
+    {
+      imagingEvent.addEventType(JPetEventType::k2Gamma);
+      imagingEvent.addEventType(JPetEventType::Prompt);
+    }
   }
   return imagingEvent;
 }

--- a/Imaging/EventCategorizerImaging.h
+++ b/Imaging/EventCategorizerImaging.h
@@ -46,6 +46,10 @@ protected:
   const std::string kDecayInto3MinAngleParamKey = "EventCategorizer_DecayInto3MinAngle_double";
   const std::string kMinAnnihilationParamKey = "EventCategorizer_MinAnnihilationTOT_double";
   const std::string kMaxAnnihilationParamKey = "EventCategorizer_MaxAnnihilationTOT_double";
+  const std::string kMinAngleWindowValueParamKey = "EventCategorizer_MinAngleWindow_double";
+  const std::string kMaxScattTestValueParamKey = "EventCategorizer_MaxScatterTest_double";
+  const std::string kMinPromptTOTParamKey = "EventCategorizer_MinPromptTOT_double";
+  const std::string kMaxPromptTOTParamKey = "EventCategorizer_MaxPromptTOT_double";
   const std::string kMaxTimeDiffParamKey = "EventCategorizer_MaxTimeDiff_double";
   const std::string kMaxZPosParamKey = "EventCategorizer_MaxHitZPos_double";
   double fMaxDistOfDecayPlaneFromCenter = 5.;
@@ -54,6 +58,10 @@ protected:
   double fScatterTOFTimeDiff = 2000.0;
   double fBackToBackAngleWindow = 3.;
   double fDecayInto3MinAngle = 190.;
+  double fScattTestValue = -500.0;
+  double fMinPromptTOT = 32000.0;
+  double fMaxPromptTOT = 50000.0;
+  double fMinAngleWindow = 15.0;
   double fMaxTimeDiff = 1000.;
   double fMaxZPos = 23.;
   bool fSaveControlHistos = true;

--- a/Imaging/EventCategorizerTools.h
+++ b/Imaging/EventCategorizerTools.h
@@ -89,10 +89,17 @@ public:
 
   static double calculatePlaneCenterDistance(const JPetHit& firstHit, const JPetHit& secondHit, const JPetHit& thirdHit);
 
-  static bool stream2Gamma(const JPetEvent& event, JPetStatistics& stats, bool saveHistos, double b2bSlotThetaDiff, double b2bTimeDiff);
-
+  static bool stream2Gamma(const JPetEvent& event, JPetStatistics& stats, bool saveHistos, double b2bSlotThetaDiff, double b2bTimeDiff, 
+                           double b2bScattTest);
+  
+  static bool stream2GammaPlus1Prompt(const JPetEvent& event, JPetStatistics& stats, bool saveHistos, double b2bSlotThetaDiff, 
+                                                    double b2bSlotThetaDiffPrompt, double b2bTimeDiff, double b2bScattTest, uint promptIndex);
+  
   static bool stream3Gamma(const JPetEvent& event, JPetStatistics& stats, bool saveHistos, double d3SlotThetaMin, double d3TimeDiff,
-                           double d3DistanceFromCenter);
+                           double d3DistanceFromCenter, double d3ScattTest);
+  
+  static double calcAngle2D(JPetHit hit1, JPetHit hit2);
+  static double scatterTest(JPetHit hit1, JPetHit hit2);
 };
 
 #endif /* !EVENTCATEGORIZERTOOLS_H */


### PR DESCRIPTION
…imaging for the positronium imaging / Formatting and binning changes

- Added angle criterion and scatter test as I use for the analysis of the data from the 3-layer prototype. Changed in stream2Gamma and stream3Gamma the methods for the calculations of the angles between the hits to the quicker and simpler version. I have added one new command, that can be used regarding setting the scatterTest cut-off.
- Left creating histograms to the old version -> probably this part need to be updated in modular version
- Formatting of the code is not as it is now in framework (clang), so I left it as it was, with some small changes to compress a little the code
- Added the streaming for the positronium imaging as it can be in near future used for the modular detector -> userParams.json should be updated with the new commands used for the positronium imaging data selection

Question: Because there is stream3Gamma without any code for the position reconstruction for 3G, should I add the code that I used in my analysis? Or it is not necessary yet? I would need to optimize it and I do not know if someone would use it for the modular analysis.